### PR TITLE
Typo: Grand Est => Grand-Est

### DIFF
--- a/sources/regions.csv
+++ b/sources/regions.csv
@@ -9,7 +9,7 @@
 "27","21231","0",BOURGOGNE FRANCHE COMTE,Bourgogne-Franche-Comté,Bourgogne-Franche-Comté
 "28","76540","0",NORMANDIE,Normandie,Normandie
 "32","59350","4",HAUTS DE FRANCE,Hauts-de-France,Hauts-de-France
-"44","67482","2",GRAND EST,Grand Est,Grand Est
+"44","67482","2",GRAND EST,Grand-Est,Grand-Est
 "52","44109","4",PAYS DE LA LOIRE,Pays de la Loire,Pays de la Loire
 "53","35238","0",BRETAGNE,Bretagne,Bretagne
 "75","33063","3",NOUVELLE AQUITAINE,Nouvelle-Aquitaine,Nouvelle-Aquitaine


### PR DESCRIPTION
Hello @jdesboeufs,

Le nom officiel de la région est "Grand-Est" avec un tiret. Merci de merge ma PR, ça devrait résourdre cette issue : opencovid19-fr/data#314